### PR TITLE
Fix the documentation on installing the transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ const Sentry = require('winston-sentry-raven-transport');
 
 const logger = new winston.Logger();
 
-logger.add(Sentry, options);
+logger.add(new Sentry(options));
 ```
 
 See [Options](#options-options) below for custom configuration.


### PR DESCRIPTION
When using the add function on the logger you should instantiate the
Sentry class and not pass it as is.